### PR TITLE
Draw antennas, add padding

### DIFF
--- a/src/lib/DisplayMode.ts
+++ b/src/lib/DisplayMode.ts
@@ -1,0 +1,4 @@
+export enum DisplayMode {
+	Heatmap = "heatmap",
+	Flowmap = "flowmap",
+}

--- a/src/lib/components/AntennaMap.svelte
+++ b/src/lib/components/AntennaMap.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { AntennaArray } from "$lib/schemas/zodSchemes";
+
+	export let antennas: AntennaArray = [];
+
+	const size = 10;
+</script>
+
+<svg id="antennamap">
+	{#each antennas as antenna}
+		<rect
+			x={antenna.x - size / 2}
+			y={antenna.y - size / 2}
+			width={size}
+			height={size}
+		/>
+	{/each}
+</svg>
+
+<style>
+	#antennamap {
+		width: 100%;
+		height: 100%;
+		translate: 0 -100%;
+	}
+</style>

--- a/src/lib/components/FlowMap.svelte
+++ b/src/lib/components/FlowMap.svelte
@@ -1,50 +1,23 @@
 <script lang="ts">
-	import { onMount } from "svelte";
-	import { rescaleLocations } from "$lib/rescaleLocations";
-	import FlowNode from "./FlowNode.svelte";
-	import debounceFn from "debounce-fn";
 	import type { Location, LocationArray } from "$lib/schemas/zodSchemes";
+	import debounceFn from "debounce-fn";
+	import FlowNode from "./FlowNode.svelte";
 
 	export let locations: LocationArray;
-
-	let flowmapElement: SVGSVGElement;
-
-	let maxX: number = 0;
-	let maxY: number = 0;
 
 	let flowNodes: { from: Location; to: Location }[] = [];
 
 	const drawLocationsDebounced = debounceFn(drawLocations, { wait: 1000 });
-	$: drawLocationsDebounced(maxX, maxY, locations);
+	$: drawLocationsDebounced(locations);
 
-	onMount(() => {
-		const resizeObserver = new ResizeObserver((entries) => {
-			const entry = entries.find(
-				(entry) => entry.target === flowmapElement,
-			);
-			if (!entry) return;
-			maxX = entry.contentRect.width;
-			maxY = entry.contentRect.height;
-		});
-		resizeObserver.observe(flowmapElement);
-		return () => {
-			resizeObserver.disconnect();
-		};
-	});
-
-	function drawLocations(
-		maxX?: number,
-		maxY?: number,
-		locations?: LocationArray,
-	) {
-		if (!maxX || !maxY || !locations) {
+	function drawLocations(locations?: LocationArray) {
+		if (!locations) {
 			return;
 		}
-		const rescaledLocations = rescaleLocations(maxX, maxY, locations);
 
 		const newFlowNodes: Map<string, { from: Location; to: Location }> =
 			new Map();
-		for (const location of rescaledLocations) {
+		for (const location of locations) {
 			if (newFlowNodes.has(location.identifier)) {
 				const entry = newFlowNodes.get(location.identifier)!;
 				if (location.calctime < entry.from.calctime) {
@@ -65,7 +38,7 @@
 	}
 </script>
 
-<svg id="flowmap" bind:this={flowmapElement}>
+<svg id="flowmap">
 	{#each flowNodes as flowNode}
 		<FlowNode from={flowNode.from} to={flowNode.to}></FlowNode>
 	{/each}
@@ -88,9 +61,7 @@
 
 <style>
 	#flowmap {
-		margin-left: auto;
-		margin-right: auto;
-		width: 90svw;
-		height: 80svh;
+		width: 100%;
+		height: 100%;
 	}
 </style>

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import type { AntennaArray, LocationArray } from "$lib/schemas/zodSchemes";
+	import { onMount } from "svelte";
+	import { DisplayMode } from "$lib/DisplayMode";
+	import { rescaleLocations } from "$lib/rescaleLocations";
+	import FlowMap from "$lib/components/FlowMap.svelte";
+	import HeatMap from "$lib/components/HeatMap.svelte";
+	import AntennaMap from "./AntennaMap.svelte";
+
+	export let displayMode: DisplayMode;
+	export let showAntennas: boolean;
+	export let antennas: AntennaArray;
+	export let locations: LocationArray;
+
+	let mapElement: HTMLElement;
+	let maxX: number;
+	let maxY: number;
+
+	let rescaledLocations: LocationArray = [];
+	let rescaledAntennas: AntennaArray = [];
+
+	$: handleData(maxX, maxY, locations, antennas);
+	function handleData(
+		maxX: number,
+		maxY: number,
+		locations: LocationArray,
+		antennas: AntennaArray,
+	) {
+		if (
+			!maxX ||
+			!maxY ||
+			!locations ||
+			!antennas ||
+			(locations.length === 0 && antennas.length === 0)
+		) {
+			return;
+		}
+		const rescaled = rescaleLocations(maxX, maxY, locations, antennas);
+		rescaledLocations = rescaled.locations;
+		rescaledAntennas = rescaled.antennas;
+	}
+
+	onMount(() => {
+		const resizeObserver = new ResizeObserver((entries) => {
+			const entry = entries.find((entry) => entry.target === mapElement);
+			if (!entry) return;
+			maxX = entry.contentRect.width;
+			maxY = entry.contentRect.height;
+		});
+		resizeObserver.observe(mapElement);
+		return () => {
+			resizeObserver.disconnect();
+		};
+	});
+</script>
+
+<div id="map" bind:this={mapElement}>
+	{#if displayMode === DisplayMode.Heatmap}
+		<HeatMap {maxX} {maxY} locations={rescaledLocations} />
+	{:else if displayMode === DisplayMode.Flowmap}
+		<FlowMap locations={rescaledLocations} />
+	{/if}
+	{#if showAntennas}
+		<AntennaMap antennas={rescaledAntennas} />
+	{/if}
+</div>
+
+<style>
+	#map {
+		margin: 0 auto;
+		width: 90svw;
+		height: 60svh;
+	}
+</style>

--- a/src/lib/grpcLiveConnections.server.ts
+++ b/src/lib/grpcLiveConnections.server.ts
@@ -17,7 +17,6 @@ const databases: Map<
 > = new Map();
 
 clientControllers.subscribe(async (map) => {
-	console.log(map);
 	for (const [serverUrl, set] of map) {
 		const database = databases.get(serverUrl);
 		if (set.size === 0) {

--- a/src/lib/grpcLiveConnections.server.ts
+++ b/src/lib/grpcLiveConnections.server.ts
@@ -36,11 +36,11 @@ clientControllers.subscribe(async (map) => {
 					const controllers =
 						get(clientControllers).get(serverUrl) ?? new Set();
 					for (const clientController of controllers) {
-						try{
+						try {
 							clientController.enqueue(eventData);
-						}catch(error){
+						} catch (error) {
 							controllers.delete(clientController);
-							clientControllers.update(map => map);
+							clientControllers.update((map) => map);
 						}
 					}
 				};

--- a/src/lib/rescaleLocations.ts
+++ b/src/lib/rescaleLocations.ts
@@ -1,26 +1,49 @@
-import type { LocationArray } from "./schemas/zodSchemes";
+import type { AntennaArray, LocationArray } from "./schemas/zodSchemes";
+
+const borderPadding = 30;
 
 export function rescaleLocations(
 	maxX: number,
 	maxY: number,
 	locations: LocationArray,
-) {
-	const realX = Math.max(...locations.map((location) => location.x));
-	const realY = Math.max(...locations.map((location) => location.y));
+	antennas: AntennaArray,
+): {
+	locations: LocationArray;
+	antennas: AntennaArray;
+} {
+	const realX = Math.max(
+		1,
+		...locations.map((location) => location.x),
+		...antennas.map((antenna) => antenna.x),
+	);
+	const realY = Math.max(
+		1,
+		...locations.map((location) => location.y),
+		...antennas.map((antenna) => antenna.y),
+	);
 
-	const scaleX = maxX / realX;
-	const scaleY = maxY / realY;
+	const scaleX = (maxX - borderPadding * 2) / realX;
+	const scaleY = (maxY - borderPadding * 2) / realY;
 
 	const rescaledLocations: LocationArray = [];
 
 	for (const location of locations) {
 		rescaledLocations.push({
-			identifier: location.identifier,
-			calctime: location.calctime,
-			x: location.x * scaleX,
-			y: location.y * scaleY,
+			...location,
+			x: location.x * scaleX + borderPadding,
+			y: location.y * scaleY + borderPadding,
 		});
 	}
 
-	return rescaledLocations;
+	const rescaledAntennas: AntennaArray = [];
+
+	for (const antenna of antennas) {
+		rescaledAntennas.push({
+			...antenna,
+			x: antenna.x * scaleX + borderPadding,
+			y: antenna.y * scaleY + borderPadding,
+		});
+	}
+
+	return { locations: rescaledLocations, antennas: rescaledAntennas };
 }

--- a/src/lib/schemas/zodSchemes.ts
+++ b/src/lib/schemas/zodSchemes.ts
@@ -28,3 +28,22 @@ export const ZodLiveResponseBody = z.object({
 });
 
 export type LiveResponseBody = z.infer<typeof ZodLiveResponseBody>;
+
+export const ZodAntenna = z.object({
+	aid: z.number(),
+	x: z.number(),
+	y: z.number(),
+});
+
+export type Antenna = z.infer<typeof ZodAntenna>;
+
+export const ZodAntennaArray = z.array(ZodAntenna).default([]);
+
+export type AntennaArray = z.infer<typeof ZodAntennaArray>;
+
+export const ZodAntennaResponseBody = z.union([
+	ZodResponseError,
+	ZodAntennaArray,
+]);
+
+export type AntennaResponseBody = z.infer<typeof ZodAntennaResponseBody>;

--- a/src/lib/state/serverUrl.ts
+++ b/src/lib/state/serverUrl.ts
@@ -1,0 +1,31 @@
+import { goto } from "$app/navigation";
+import { writable, type Writable } from "svelte/store";
+
+const urlParamKey: string = "url";
+
+let initialValue = "";
+
+// Get the value from the URL at load
+if ("location" in globalThis) {
+	const params = new URLSearchParams(globalThis.location.search);
+	const urlValue = params.get(urlParamKey);
+	if(urlValue && URL.canParse(urlValue)){
+		initialValue = urlValue;
+	}
+}
+
+export const serverUrl: Writable<string> = writable(initialValue);
+
+
+// If the value updates, set it in the URL
+if ("location" in globalThis && "history" in globalThis) {
+	serverUrl.subscribe((serverUrl) => {
+		const url = new URL(globalThis.location.href);
+		if(serverUrl){
+			url.searchParams.set(urlParamKey, serverUrl);
+		}else{
+			url.searchParams.delete(urlParamKey);
+		}
+		goto(url, { replaceState: true, keepFocus: true });
+	});
+}

--- a/src/lib/state/serverUrl.ts
+++ b/src/lib/state/serverUrl.ts
@@ -9,21 +9,20 @@ let initialValue = "";
 if ("location" in globalThis) {
 	const params = new URLSearchParams(globalThis.location.search);
 	const urlValue = params.get(urlParamKey);
-	if(urlValue && URL.canParse(urlValue)){
+	if (urlValue && URL.canParse(urlValue)) {
 		initialValue = urlValue;
 	}
 }
 
 export const serverUrl: Writable<string> = writable(initialValue);
 
-
 // If the value updates, set it in the URL
 if ("location" in globalThis && "history" in globalThis) {
 	serverUrl.subscribe((serverUrl) => {
 		const url = new URL(globalThis.location.href);
-		if(serverUrl){
+		if (serverUrl) {
 			url.searchParams.set(urlParamKey, serverUrl);
-		}else{
+		} else {
 			url.searchParams.delete(urlParamKey);
 		}
 		goto(url, { replaceState: true, keepFocus: true });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { browser } from "$app/environment";
 	import debounce from "debounce-fn";
+	import { serverUrl } from "$lib/state/serverUrl";
 	import { dateToDatetimeString } from "$lib/dateTools";
 	import { URLParams } from "$lib/urlSearchParams";
 	import Map from "$lib/components/Map.svelte";
@@ -22,12 +23,17 @@
 	let addressStatus: AddressStatus = AddressStatus.Initial;
 
 	let urlInputElement: HTMLInputElement;
-	let inputServerUrl: string;
-	let serverUrl: string;
-	$: if (inputServerUrl && urlInputElement) {
+	let inputServerUrl: string = $serverUrl;
+	const setNewServerUrlDebounced= debounce(setNewServerUrl, {
+		wait: 500,
+	});
+	$: setNewServerUrlDebounced(inputServerUrl, urlInputElement);
+	function setNewServerUrl(inputServerUrl: string, urlInputElement: HTMLInputElement){
+		if (inputServerUrl && urlInputElement) {
 		if (urlInputElement.reportValidity()) {
-			serverUrl = inputServerUrl;
+			$serverUrl = inputServerUrl;
 		}
+	}
 	}
 
 	let timeIntervalBegin = dateToDatetimeString(new Date());
@@ -36,8 +42,8 @@
 	let locationStream: EventSource | undefined;
 	let isLive = false;
 	let showAntennas = true;
-	$: if (showAntennas && serverUrl) {
-		getAntennasDebounced(serverUrl);
+	$: if (showAntennas && $serverUrl) {
+		getAntennasDebounced($serverUrl);
 	}
 
 	let displayMode: DisplayMode = DisplayMode.Heatmap;
@@ -50,7 +56,7 @@
 		wait: 1000,
 	});
 	$: handleNewDataSettingsDebounced(
-		serverUrl,
+		$serverUrl,
 		isLive,
 		timeIntervalBegin,
 		timeIntervalOffset,
@@ -281,9 +287,9 @@
 	</label>
 	<button
 		on:click={() => {
-			getAntennasDebounced(serverUrl);
+			getAntennasDebounced($serverUrl);
 		}}
-		disabled={!serverUrl}
+		disabled={!$serverUrl}
 	>
 		Refresh antennas
 	</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,7 +50,6 @@
 
 	let locations: LocationArray = [];
 	let antennas: AntennaArray = [];
-	$: console.log(antennas);
 
 	const handleNewDataSettingsDebounced = debounce(handleNewDataSettings, {
 		wait: 1000,
@@ -202,7 +201,6 @@
 		wait: 500,
 	});
 	async function getAntennas(serverUrl: string) {
-		console.log("getting antennas");
 		const fetchUrl = new URL("/api/getAntennas", window.location.origin);
 		fetchUrl.searchParams.set(URLParams.serverUrl, serverUrl);
 		const response = await fetch(fetchUrl, {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,16 +24,19 @@
 
 	let urlInputElement: HTMLInputElement;
 	let inputServerUrl: string = $serverUrl;
-	const setNewServerUrlDebounced= debounce(setNewServerUrl, {
+	const setNewServerUrlDebounced = debounce(setNewServerUrl, {
 		wait: 500,
 	});
 	$: setNewServerUrlDebounced(inputServerUrl, urlInputElement);
-	function setNewServerUrl(inputServerUrl: string, urlInputElement: HTMLInputElement){
+	function setNewServerUrl(
+		inputServerUrl: string,
+		urlInputElement: HTMLInputElement,
+	) {
 		if (inputServerUrl && urlInputElement) {
-		if (urlInputElement.reportValidity()) {
-			$serverUrl = inputServerUrl;
+			if (urlInputElement.reportValidity()) {
+				$serverUrl = inputServerUrl;
+			}
 		}
-	}
 	}
 
 	let timeIntervalBegin = dateToDatetimeString(new Date());

--- a/src/routes/api/getAntennas/+server.ts
+++ b/src/routes/api/getAntennas/+server.ts
@@ -1,0 +1,128 @@
+import type { RequestHandler } from "./$types";
+import type { RoutesClient } from "../../../../gen/protobuf/cdm_protobuf/Routes.ts";
+import type { GetAntennasResponse__Output } from "../../../../gen/protobuf/cdm_protobuf/GetAntennasResponse";
+import { json } from "@sveltejs/kit";
+import { URLParams } from "$lib/urlSearchParams";
+import { createClient } from "$lib/grpcClient";
+import {
+	type AntennaResponseBody,
+	type AntennaArray,
+	ZodResponseBody,
+} from "$lib/schemas/zodSchemes";
+
+enum RequestStateEnum {
+	INIT = 0,
+	ERROR = 1,
+}
+
+class RequestState {
+	private state: RequestStateEnum;
+	private message: string | undefined;
+
+	constructor(state: RequestStateEnum, message?: string) {
+		this.state = state;
+		if (message) this.message = message;
+	}
+
+	setState(state: RequestStateEnum, message?: string) {
+		this.state = state;
+		if (message) this.message = message;
+	}
+
+	getState(): { state: RequestStateEnum; message?: string } {
+		return { state: this.state, message: this.message };
+	}
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	const requestState = new RequestState(RequestStateEnum.INIT);
+	const response: AntennaArray = [];
+
+	const url = new URL(request.url);
+	const serverURL = url.searchParams.get(URLParams.serverUrl);
+
+	let client: RoutesClient;
+
+	if (serverURL === null) {
+		requestState.setState(
+			RequestStateEnum.ERROR,
+			"Invalid request parameters",
+		);
+		return createResponse(requestState, response);
+	}
+
+	try {
+		client = await createClient(serverURL);
+	} catch (error) {
+		requestState.setState(
+			RequestStateEnum.ERROR,
+			`Unable to create gRPC client for CDM-Server on ${serverURL}`,
+		);
+		return createResponse(requestState, response);
+	}
+
+	try {
+		const getAntennas = () => {
+			return new Promise<void>((resolve, reject) => {
+				client.GetAntennasRoute(
+					{},
+					(
+						err: Error | null,
+						val: GetAntennasResponse__Output | undefined,
+					) => {
+						if (err !== null) {
+							requestState.setState(
+								RequestStateEnum.ERROR,
+								`Error while fetching data: ${err.message}`,
+							);
+							reject(err);
+						} else {
+							for (const antenna of val?.antenna || []) {
+								if (
+									antenna.aid !== undefined &&
+									antenna.x !== undefined &&
+									antenna.y !== undefined
+								) {
+									response.push({
+										aid: antenna.aid,
+										x: antenna.x,
+										y: antenna.y,
+									});
+								}
+							}
+
+							resolve();
+						}
+					},
+				);
+			});
+		};
+
+		await getAntennas();
+	} catch (error) {
+		requestState.setState(
+			RequestStateEnum.ERROR,
+			`Error while connecting to gRPC server: ${error}`,
+		);
+		return createResponse(requestState, response);
+	}
+
+	if (requestState.getState().state === RequestStateEnum.ERROR) {
+		return createResponse(requestState, response);
+	}
+
+	return createResponse(requestState, response);
+};
+
+function createResponse(
+	requestState: RequestState,
+	response: AntennaResponseBody,
+): Response {
+	if (requestState.getState().state === RequestStateEnum.ERROR) {
+		const response = ZodResponseBody.parse({
+			error: requestState.getState().message,
+		});
+		return json(response, { status: 400 });
+	}
+	return json(response, { status: 200 });
+}


### PR DESCRIPTION
The client will now fetch antenna data and display the antennas on the map as squares.

Part of this implementation was to add a `Map` component which now handles rescaling of positions, something which was previously handled by `FlowMap`, `HeatMap`, and `AntennaMap` separately.

I also added padding to the rescaling algorithm, allowing data points to be shown even though they're right at the border of the data plot.